### PR TITLE
CELDEV-1304 - update checkAuth to set context user

### DIFF
--- a/celements-spring-security/src/main/java/com/celements/spring/security/AuthenticatedBaseController.java
+++ b/celements-spring-security/src/main/java/com/celements/spring/security/AuthenticatedBaseController.java
@@ -61,7 +61,9 @@ public abstract class AuthenticatedBaseController {
       XWikiContext xcontext = eCtx.get(XWIKI_CONTEXT).orElseThrow();
       XWikiUser xuser = xwiki.checkAuth(xcontext);
       if (xuser != null) {
-        var user = userService.getUser(xuser.getUser());
+        // resolve user BEFORE setting in xcontext to avoid leaving an invalid user
+        // if getUser throws (e.g. user doc/object deleted between auth and lookup)
+        User user = userService.getUser(xuser.getUser());
         xcontext.setUser(xuser.getUser(), xuser.isMain());
         return Optional.of(user);
       }

--- a/celements-spring-security/src/main/java/com/celements/spring/security/AuthenticatedBaseController.java
+++ b/celements-spring-security/src/main/java/com/celements/spring/security/AuthenticatedBaseController.java
@@ -61,8 +61,9 @@ public abstract class AuthenticatedBaseController {
       XWikiContext xcontext = eCtx.get(XWIKI_CONTEXT).orElseThrow();
       XWikiUser xuser = xwiki.checkAuth(xcontext);
       if (xuser != null) {
+        var user = userService.getUser(xuser.getUser());
         xcontext.setUser(xuser.getUser(), xuser.isMain());
-        return Optional.of(userService.getUser(xuser.getUser()));
+        return Optional.of(user);
       }
     } catch (XWikiException | UserInstantiationException exc) {
       logger.warn("Failed to check auth", exc);
@@ -77,7 +78,7 @@ public abstract class AuthenticatedBaseController {
   protected ResponseEntity<String> toErrorResponse(HttpStatus status, Exception e) {
     String body = rightsAccess.isSuperAdmin()
         ? ExceptionUtils.getStackTrace(e)
-        : "Error:" + e.getMessage();
+        : "Error: " + e.getMessage();
     return ResponseEntity.status(status).body(body);
   }
 

--- a/celements-spring-security/src/main/java/com/celements/spring/security/AuthenticatedBaseController.java
+++ b/celements-spring-security/src/main/java/com/celements/spring/security/AuthenticatedBaseController.java
@@ -48,6 +48,9 @@ public abstract class AuthenticatedBaseController {
    * This is necessary because the system supports Struts-only sessions that have
    * no Spring Security principal, so Spring's isAuthenticated() alone is insufficient.
    *
+   * When legacy auth succeeds, the authenticated user is written back to the XWiki context so
+   * downstream model services see the same current user as Struts request handling would provide.
+   *
    * Long-term improvement, this bridge should move into the Spring Security filter chain so
    * legacy-authenticated users populate the SecurityContext before controller authorization runs.
    */
@@ -58,6 +61,7 @@ public abstract class AuthenticatedBaseController {
       XWikiContext xcontext = eCtx.get(XWIKI_CONTEXT).orElseThrow();
       XWikiUser xuser = xwiki.checkAuth(xcontext);
       if (xuser != null) {
+        xcontext.setUser(xuser.getUser(), xuser.isMain());
         return Optional.of(userService.getUser(xuser.getUser()));
       }
     } catch (XWikiException | UserInstantiationException exc) {

--- a/celements-spring-security/src/test/java/com/celements/spring/security/AuthenticatedBaseControllerTest.java
+++ b/celements-spring-security/src/test/java/com/celements/spring/security/AuthenticatedBaseControllerTest.java
@@ -1,0 +1,137 @@
+package com.celements.spring.security;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
+
+import com.celements.auth.user.User;
+import com.celements.auth.user.UserInstantiationException;
+import com.celements.auth.user.UserService;
+import com.celements.common.test.AbstractComponentTest;
+import com.celements.rights.access.IRightsAccessFacadeRole;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.user.api.XWikiUser;
+
+public class AuthenticatedBaseControllerTest extends AbstractComponentTest {
+
+  private TestController controller;
+  private UserService userServiceMock;
+  private User userMock;
+
+  /**
+   * Concrete subclass of the abstract {@link AuthenticatedBaseController} for testing.
+   * The {@code @PreAuthorize("permitAll()")} override is necessary to prevent Spring Security
+   * from rejecting calls in the test environment which has no authenticated SecurityContext.
+   */
+  @Component
+  @PreAuthorize("permitAll()")
+  static class TestController extends AuthenticatedBaseController {
+    // only exists to make the abstract class instantiable for tests
+  }
+
+  @Before
+  public void prepare() throws Exception {
+    userServiceMock = registerComponentMock(UserService.class);
+    registerComponentMock(IRightsAccessFacadeRole.class);
+    userMock = createDefaultMock(User.class);
+    controller = getBeanFactory().createBean(TestController.class);
+  }
+
+  @Test
+  public void test_checkAuth_success() throws Exception {
+    String userName = "XWiki.TestUser";
+    XWikiUser xuser = new XWikiUser(userName);
+    expect(getXContext().getWiki().checkAuth(same(getXContext()))).andReturn(xuser);
+    expect(userServiceMock.getUser(eq(userName))).andReturn(userMock);
+    replayDefault();
+
+    Optional<User> result = controller.checkAuth();
+
+    verifyDefault();
+    assertTrue(result.isPresent());
+    assertSame(userMock, result.get());
+    assertEquals(userName, getXContext().getUser());
+  }
+
+  @Test
+  public void test_checkAuth_UserInstantiationException_xcontextUnchanged() throws Exception {
+    String userName = "XWiki.DeletedUser";
+    String originalUser = getXContext().getUser();
+    XWikiUser xuser = new XWikiUser(userName);
+    expect(getXContext().getWiki().checkAuth(same(getXContext()))).andReturn(xuser);
+    expect(userServiceMock.getUser(eq(userName)))
+        .andThrow(new UserInstantiationException("No user object on doc: " + userName));
+    replayDefault();
+
+    Optional<User> result = controller.checkAuth();
+
+    verifyDefault();
+    assertTrue("should return empty on UserInstantiationException", result.isEmpty());
+    assertEquals("xcontext user must not be changed when getUser throws",
+        originalUser, getXContext().getUser());
+  }
+
+  @Test
+  public void test_checkAuth_guestUser_returnsEmpty() throws Exception {
+    String originalUser = getXContext().getUser();
+    expect(getXContext().getWiki().checkAuth(same(getXContext()))).andReturn(null);
+    replayDefault();
+
+    Optional<User> result = controller.checkAuth();
+
+    verifyDefault();
+    assertTrue("should return empty for guest (null XWikiUser)", result.isEmpty());
+    assertEquals("xcontext user must not be changed for guest",
+        originalUser, getXContext().getUser());
+  }
+
+  @Test
+  public void test_checkAuth_XWikiException_returnsEmpty() throws Exception {
+    String originalUser = getXContext().getUser();
+    expect(getXContext().getWiki().checkAuth(same(getXContext())))
+        .andThrow(new XWikiException());
+    replayDefault();
+
+    Optional<User> result = controller.checkAuth();
+
+    verifyDefault();
+    assertTrue("should return empty on XWikiException", result.isEmpty());
+    assertEquals("xcontext user must not be changed on XWikiException",
+        originalUser, getXContext().getUser());
+  }
+
+  @Test
+  public void test_checkAuth_predicate_success() throws Exception {
+    String userName = "XWiki.TestUser";
+    XWikiUser xuser = new XWikiUser(userName);
+    expect(getXContext().getWiki().checkAuth(same(getXContext()))).andReturn(xuser);
+    expect(userServiceMock.getUser(eq(userName))).andReturn(userMock);
+    replayDefault();
+
+    boolean result = controller.checkAuth(user -> user == userMock);
+
+    verifyDefault();
+    assertTrue("predicate matching the user should return true", result);
+  }
+
+  @Test
+  public void test_checkAuth_predicate_noMatch() throws Exception {
+    String userName = "XWiki.TestUser";
+    XWikiUser xuser = new XWikiUser(userName);
+    expect(getXContext().getWiki().checkAuth(same(getXContext()))).andReturn(xuser);
+    expect(userServiceMock.getUser(eq(userName))).andReturn(userMock);
+    replayDefault();
+
+    boolean result = controller.checkAuth(user -> false);
+
+    verifyDefault();
+    assertFalse("predicate rejecting the user should return false", result);
+  }
+
+}


### PR DESCRIPTION
This branch fixes the legacy-auth bridge in `AuthenticatedBaseController`.

`checkAuth()` already authenticated successfully via `xwiki.checkAuth(xcontext)`, but the returned `XWikiUser` was only converted to a celements `User` and not written back into the `XWikiContext`. That meant downstream code using `ModelContext.user()` could still see an empty/current guest context in Spring controller requests, even though legacy auth had succeeded.

The fix now mirrors the Struts/XWiki request handling pattern by calling:

```java
xcontext.setUser(xuser.getUser(), xuser.isMain());