### PR TITLE
CELDEV-1334 Add current-wiki REST reference ADR

### DIFF
--- a/celements-spring-mvc/pom.xml
+++ b/celements-spring-mvc/pom.xml
@@ -45,6 +45,12 @@
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-webmvc-core</artifactId>
     </dependency>
+    <!-- Springdoc's ModelResolver loads XmlRootElement reflectively on Java 21. -->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
   </dependencies>
   <scm>

--- a/docs/adr/0001-current-wiki-scoped-rest-references.md
+++ b/docs/adr/0001-current-wiki-scoped-rest-references.md
@@ -1,0 +1,45 @@
+# ADR 0001: Current-Wiki-Scoped REST References
+
+- Status: accepted
+- Date: 2026-07-30
+
+## Context
+
+Celements REST endpoints may accept XWiki document and space references. A
+wiki-qualified reference can cross a tenant boundary, even when its qualifier
+names the wiki currently handling the request. Accepting such references
+without an explicit cross-wiki authorization and information-disclosure
+contract risks exposing the existence or content of resources outside the
+endpoint's intended scope.
+
+REST responses also need one stable representation of references. Returning
+wiki-qualified and local references interchangeably would make contracts
+caller- and deployment-dependent.
+
+## Decision
+
+REST endpoints scoped to the wiki handling the request accept only canonical
+local document and space references.
+
+- Reject malformed, noncanonical, or wiki-qualified input references.
+- Reject a wiki-qualified input even when its qualifier names the current wiki.
+- Serialize response references canonically and locally.
+- Treat a syntactically valid local reference with no visible result according
+  to the endpoint's resource contract; do not infer a cross-wiki lookup.
+- Do not reveal whether a rejected or inaccessible cross-wiki resource exists.
+
+An endpoint that needs cross-wiki access must define a separate contract. That
+contract must explicitly cover authorization, tenant boundaries, reference
+serialization, and information disclosure before implementation.
+
+## Consequences
+
+- Current-wiki endpoints have an unambiguous tenant boundary.
+- Clients cannot use a current-wiki endpoint as a cross-wiki discovery
+  mechanism.
+- Request validation must distinguish canonical local references from malformed,
+  noncanonical, and wiki-qualified input.
+- Responses remain portable because their references do not depend on the
+  current wiki name.
+- Cross-wiki use cases require deliberate API design rather than an implicit
+  extension of a local endpoint.

--- a/docs/adr/0001-current-wiki-scoped-rest-references.md
+++ b/docs/adr/0001-current-wiki-scoped-rest-references.md
@@ -5,16 +5,18 @@
 
 ## Context
 
-Celements REST endpoints may accept XWiki document and space references. A
-wiki-qualified reference can cross a tenant boundary, even when its qualifier
-names the wiki currently handling the request. Accepting such references
-without an explicit cross-wiki authorization and information-disclosure
-contract risks exposing the existence or content of resources outside the
-endpoint's intended scope.
+Celements REST endpoints may accept XWiki document and space references. For an
+endpoint scoped to the wiki handling the request, the request context already
+defines the tenant boundary. A wiki qualifier introduces a second scope
+selector: naming another wiki conflicts with the endpoint's scope, while naming
+the current wiki creates an alternative representation and makes a
+deployment-specific wiki name part of the public contract.
 
-REST responses also need one stable representation of references. Returning
-wiki-qualified and local references interchangeably would make contracts
-caller- and deployment-dependent.
+Requests and responses need one stable representation of references. Supporting
+both qualified and local forms would make the contract caller-dependent, while
+returning qualified references would make it deployment-dependent. Exposing or
+accepting a cross-wiki scope requires an explicit authorization and
+information-disclosure contract.
 
 ## Decision
 
@@ -34,12 +36,15 @@ serialization, and information disclosure before implementation.
 
 ## Consequences
 
-- Current-wiki endpoints have an unambiguous tenant boundary.
-- Clients cannot use a current-wiki endpoint as a cross-wiki discovery
-  mechanism.
-- Request validation must distinguish canonical local references from malformed,
-  noncanonical, and wiki-qualified input.
-- Responses remain portable because their references do not depend on the
-  current wiki name.
-- Cross-wiki use cases require deliberate API design rather than an implicit
-  extension of a local endpoint.
+- Clients holding qualified references, including references qualified with the
+  current wiki, must serialize them locally before calling these endpoints.
+- Response references are contextual identifiers for the wiki serving the
+  response, not globally unique identifiers. A client moving them between
+  request contexts must retain the source-wiki context separately.
+- Payloads neither expose nor depend on internal wiki names, so the same local
+  reference representation can be used in deployments with different wiki
+  names.
+- Validation can reject every qualifier uniformly without comparing a supplied
+  wiki name with the current wiki or disclosing whether it matched.
+- Cross-wiki clients need a separate API contract with a public tenant identity,
+  authorization rules, and defined disclosure behavior.

--- a/docs/adr/0001-current-wiki-scoped-rest-references.md
+++ b/docs/adr/0001-current-wiki-scoped-rest-references.md
@@ -1,6 +1,6 @@
 # ADR 0001: Current-Wiki-Scoped REST References
 
-- Status: accepted
+- Status: DRAFT
 - Date: 2026-07-30
 
 ## Context


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-1334
## Summary

- record canonical local document and space references as the convention for current-wiki REST endpoints
- reject wiki-qualified inputs, including qualifiers naming the current wiki
- require an explicit authorization and disclosure contract for future cross-wiki APIs

## Coordinated delivery

Draft 1 of 4 for CELDEV-1334:

1. celements/celements-spring#31
2. celements/celements-base#309
3. celements/celements-parent-poms#142
4. celements/celements-web#556

## Validation

- documentation reviewed against `NAVIGATION_API_PLAN.md`
- coordinated local build, REST contract tests, WAR packaging, and runtime smoke checks completed
- manually tested and approved by the requester